### PR TITLE
Add a Max amount button to dump all

### DIFF
--- a/packages/website/components/dump-box/dump-box-layout.tsx
+++ b/packages/website/components/dump-box/dump-box-layout.tsx
@@ -15,7 +15,7 @@ export const DumpBoxLayout = ({message, children, style}: Props) => {
 
             {message}
             <div
-                className={`max-w-md mx-auto flex flex-col items-center mt-10 rounded-lg
+                className={`max-w-md mx-auto flex flex-col mt-10 rounded-lg
            p-4 shadow-md gap-y-4 ${style === 'in-progress' ? "bg-orange border border-4 border-black text-black" : "bg-rich-black text-white"}  break-words`}
 
             >

--- a/packages/website/components/layout.tsx
+++ b/packages/website/components/layout.tsx
@@ -1,5 +1,4 @@
 import type {ReactNode} from "react";
-import styles from "../styles/Home.module.css";
 import Head from "next/head";
 import {NavBar} from "./nav-bar";
 import Notification from "./notifications/notifications";

--- a/packages/website/utils/maxAmountSpend.ts
+++ b/packages/website/utils/maxAmountSpend.ts
@@ -1,0 +1,34 @@
+/**
+ * Code copied from uniswap/interface
+ * https://github.com/Uniswap/interface/blob/main/src/utils/maxAmountSpend.ts
+ *
+ * Modified to keep 3 times .01 ETH - .01 ETH for tx fee and .02 ETH if the tx fails and the user needs to refund
+ */
+
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import JSBI from 'jsbi'
+
+// keep .01 ETH for gas for the transaction itself, and keep .01 ETH for eventual gas for a refund and .01 ETH for the actual refund tx cost
+const MIN_NATIVE_CURRENCY_FOR_GAS: JSBI = JSBI.multiply(
+  JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(16)),
+  JSBI.BigInt(3)
+) // .03 ETH
+
+/**
+ * Given some token amount, return the max that can be spent of it
+ * @param currencyAmount to return max of
+ */
+export function maxAmountSpend(currencyAmount?: CurrencyAmount<Currency>): CurrencyAmount<Currency> | undefined {
+  if (!currencyAmount) return undefined
+  if (currencyAmount.currency.isNative) {
+    if (JSBI.greaterThan(currencyAmount.quotient, MIN_NATIVE_CURRENCY_FOR_GAS)) {
+      return CurrencyAmount.fromRawAmount(
+        currencyAmount.currency,
+        JSBI.subtract(currencyAmount.quotient, MIN_NATIVE_CURRENCY_FOR_GAS)
+      )
+    } else {
+      return CurrencyAmount.fromRawAmount(currencyAmount.currency, JSBI.BigInt(0))
+    }
+  }
+  return currencyAmount
+}


### PR DESCRIPTION
Instead of typing the total balance amount one could use the max button to dump all his ETH. The max is "max - 0.3" - we leave 0.1 for the current transaction cost, 0.1 ETH for eventual gas cost for a refund tx and 0.1 for the tx cost of refund.

This means that if a swap is matched - then there are 0.3 ETH left, but better like that, that to lock all the ETH in the contract and then not being able to withdraw it.