### PR TITLE
Add test setup for the bot using local hardhat nodes

### DIFF
--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -1,3 +1,3 @@
 POS_URL="http://localhost:8545"
 POW_URL="http://localhost:8546"
-PRIVKEY_MNEMONIC="candy maple velvet cake sugar cream honey rich smooth crumble sweet treat"
+PRIVKEY_MNEMONIC="test test test test test test test test test test test junk"

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -2,6 +2,7 @@ import { HardhatUserConfig } from "hardhat/config";
 import { config as dotenvConfig } from "dotenv";
 import "@nomicfoundation/hardhat-toolbox";
 import "hardhat-deploy";
+import "hardhat-change-network";
 
 dotenvConfig();
 
@@ -33,7 +34,7 @@ if (isCI) {
     mnemonic: seed,
     path: "m/44'/60'/0'/0",
     initialIndex: 0,
-    count: 10,
+    count: 20,
     passphrase: ""
   };
   config = {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -30,5 +30,8 @@
     "ts-node": "^10.9.1",
     "typechain": "^8.1.0",
     "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "hardhat-change-network": "^0.0.7"
   }
 }

--- a/packages/contracts/test/Bot.ts
+++ b/packages/contracts/test/Bot.ts
@@ -1,0 +1,92 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import {randomBytes} from "ethers/lib/utils"
+import {BigNumber} from "ethers"
+import {EtherSwap} from "../typechain-types"
+import exp from "constants"
+
+const hre = require("hardhat");
+
+describe("Bot", function () {
+
+  const recipientChangeLockDuration = 10*60;
+  const feeRecipient = "0x5678000000000000000000000000000000001234";
+  const feePerMillion = 1000
+
+  const lockTime = 365 * 24 * 60 * 60;
+  let transactionExpiry: number;
+  const secret = randomBytes(32)
+  const hashedSecret = ethers.utils.keccak256(secret)
+  const expectedAmount = 1
+  const swapValue = 1_000
+  const swapFee = 1
+  const msgValue = swapValue + swapFee
+  let recipient = ""
+  let txSender = ""
+
+  before(async function() {
+    recipient = (await ethers.getSigners())[1].address
+    txSender = (await ethers.getSigners())[0].address
+    transactionExpiry = (await ethers.provider.getBlock("latest")).timestamp * 100
+  });
+
+  // We define a fixture to reuse the same setup in every test.
+  // We use loadFixture to run this setup once, snapshot that state,
+  // and reset Hardhat Network to that snapshopt in every test.
+  async function deployEtherSwap() {
+    const EtherSwapFactory = await ethers.getContractFactory("EtherSwap");
+    return EtherSwapFactory.deploy(recipientChangeLockDuration, ethers.constants.AddressZero, 0);
+  }
+
+  async function deployEtherSwapWithFees() {
+    const EtherSwapFactory = await ethers.getContractFactory("EtherSwap");
+    return EtherSwapFactory.deploy(recipientChangeLockDuration, feeRecipient, feePerMillion);
+  }
+
+  async function deployCommit() {
+    const etherSwap = await deployEtherSwap()
+
+    await etherSwap['commit(uint64,uint64,bytes32,uint256,uint256,address)'](transactionExpiry, lockTime, hashedSecret, swapValue, expectedAmount, ethers.constants.AddressZero, {"value": swapValue})
+
+    return {etherSwap, secret};
+  }
+
+  async function deployCommitWithFees() {
+    const etherSwap = await deployEtherSwapWithFees()
+
+    await etherSwap['commit(uint64,uint64,bytes32,uint256,uint256,address)'](transactionExpiry, lockTime, hashedSecret, swapValue, expectedAmount, recipient, {"value": msgValue})
+
+    return etherSwap;
+  }
+
+  describe("Bot setup", function () {
+
+    it("Should commit with transaction expiry time and swap lock time", async function () {
+      hre.changeNetwork('pos_local');
+
+      const etherSwap = await loadFixture(deployEtherSwap);
+
+      await etherSwap['commit(uint64,uint64,bytes32,uint256,uint256,address)'](
+        transactionExpiry, lockTime, hashedSecret, swapValue, expectedAmount, ethers.constants.AddressZero, {"value": swapValue})
+
+      const blockTime = (await ethers.provider.getBlock("latest")).timestamp
+
+      const commit = await etherSwap.swaps(0)
+      expect(commit.hashedSecret).to.equal(ethers.utils.hexlify(hashedSecret))
+      expect(commit.initiator).to.equal(txSender)
+      expect(commit.endTimeStamp).to.equal(blockTime + lockTime)
+      expect(commit.recipient).to.equal(ethers.constants.AddressZero)
+      expect(commit.changeRecipientTimestamp).to.equal(0)
+      expect(commit.value).to.equal(swapValue)
+      expect(commit.expectedAmount).to.equal(expectedAmount)
+
+      expect(await etherSwap.provider.getBalance(etherSwap.address)).to.equal(swapValue)
+      console.log((await ethers.provider.getBlock("latest")).number)
+
+      hre.changeNetwork('pow_local')
+      console.log((await ethers.provider.getBlock("latest")).number)
+
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5786,6 +5786,11 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
+hardhat-change-network@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/hardhat-change-network/-/hardhat-change-network-0.0.7.tgz#9f9b7943ff966515658b70bf5e44bc2f073af402"
+  integrity sha512-Usp9fJan9SOJnOlVcv/jMJDchseE7bIDA5ZsBnracgVk4MiBwkvMqpmLWn5G1aDBvnUCthvS2gO3odfahgkV0Q==
+
 hardhat-deploy@^0.11.12:
   version "0.11.12"
   resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.11.12.tgz#323e05ecd8e6c80a9193b9c6f6c8ecbb6abfbe47"
@@ -10482,22 +10487,6 @@ uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
-
-uuidv4@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/uuidv4/-/uuidv4-2.0.0.tgz"
-  integrity sha512-sAUlwUVepcVk6bwnaW/oi6LCwMdueako5QQzRr90ioAVVcms6p1mV0PaSxK8gyAC4CRvKddsk217uUpZUbKd2Q==
-  dependencies:
-    sha-1 "0.1.1"
-    uuid "3.3.2"
-
-uuidv4@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/uuidv4/-/uuidv4-3.0.1.tgz"
-  integrity sha512-PPzksdWRl2a5C9hrs3OOYrArTeyoR0ftJ3jtOy+BnVHkT2UlrrzPNt9nTdiGuxmQItHM/AcTXahwZZC57Njojg==
-  dependencies:
-    uuid "3.3.2"
-
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Draft of setup to test the bot

- update your .env with correct mnemonic
- run `npx hardhat node --port 8545`
- run `npx hardhat node --port 8546`
- run `npx hardhat test`
- use `hre.changeNetwork('pow_local')` or `hre.changeNetwork('pos_local')` to connect to either network