### PR TITLE
Fix failure to resume failed swap 0

### DIFF
--- a/packages/website/components/detect-swaps/detect-non-complete-swaps.tsx
+++ b/packages/website/components/detect-swaps/detect-non-complete-swaps.tsx
@@ -65,8 +65,8 @@ export const DetectNonCompleteSwaps = () => {
           const log = getCommitLog(txReceipt)
 
           if (log.name === 'Commit') {
-            if (log.args.id) {
-              setSwapSecrets(log.args.id, txSecrets[txHash])
+            if (log.args && typeof log.args.id === 'number' && log.args.id >= 0) {
+              setSwapSecrets(String(log.args.id), txSecrets[txHash])
             }
           }
 


### PR DESCRIPTION
If for some reason the very first user of the swap was to refresh the page right after submitting his tx he wouldn’t be able to resume the swap as we were losing the swap secret from localstorage.