### PR TITLE
Allow contract compile without specifying a .env

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -28,7 +28,7 @@ if (isCI) {
   const pos_url = (process.env.POS_URL as string) || "http://localhost:8545";
   const etherscan_goerli_api_key = (process.env.ETHERSCAN_GOERLI_API_KEY as string) || "";
 
-  const seed = process.env.PRIVKEY_MNEMONIC as string;
+  const seed = process.env.PRIVKEY_MNEMONIC as string || "test test test test test test test test test test test junk";
   const default_accounts = {
     mnemonic: seed,
     path: "m/44'/60'/0'/0",


### PR DESCRIPTION
Currently the default _accounts require a seed, which is being provided as an environement variable. When cloning the repo and just compiling it’s not necessary to provide a private key. If no PRIVKEY_MNEMONIC is provided I’m setting it to the default value specified in the hardhat docs: https://hardhat.org/hardhat-network/docs/reference