### PR TITLE
fix: Has ended status was wrong if tx was emptied

### DIFF
--- a/packages/website/components/connectors/transaction-history.tsx
+++ b/packages/website/components/connectors/transaction-history.tsx
@@ -112,7 +112,7 @@ export const TransactionHistory = () => {
                 {formatEther(swap.value)}
               </div>
               <div>
-                <span className={'font-bold'}>Has ended:</span> {hasExpired ? 'Yes' : 'No'}
+                <span className={'font-bold'}>Has ended:</span> {hasExpired || swap.emptied ? 'Yes' : 'No'}
               </div>
               {hasExpired && (
                 <div>


### PR DESCRIPTION
If someone has emptied the swap, then we are dealing with a completed swap.